### PR TITLE
fix: improved accessibility for time display

### DIFF
--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -57,13 +57,11 @@ class TimeDisplay extends Component {
     this.contentEl_ = Dom.createEl('span', {
       className: `${className}-display`
     }, {
-      // tell screen readers not to automatically read the time as it changes
-      'aria-live': 'off',
       // span elements have no implicit role, but some screen readers (notably VoiceOver)
       // treat them as a break between items in the DOM when using arrow keys
       // (or left-to-right swipes on iOS) to read contents of a page. Using
       // role='presentation' causes VoiceOver to NOT treat this span as a break.
-      'role': 'presentation'
+      role: 'presentation'
     });
 
     el.appendChild(this.contentEl_);


### PR DESCRIPTION
This change is to remove the aria-live attribute from time display elements. The aria-live attribute is no longer needed since the presentation role was added. Both attributes being present can lead to unexpected screen reader behavior. Fixes issue #8143

## Description
See Bug issue in videojs/videojs repo: https://github.com/videojs/video.js/issues/8143

## Specific Changes proposed
Remove aria-live="off" from all time display elements within the player since they already have role="presentation"

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
